### PR TITLE
Added missing backslash in shell command

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -21,7 +21,7 @@ source code directory.
         -w /build \
         --name lms2012_armhf \
         -e "TERM=$TERM" \
-        -e "DESTDIR=/build/dist"
+        -e "DESTDIR=/build/dist" \
         -td lms2012-armhf tail
 
     Some notes:


### PR DESCRIPTION
If you just copy-pasted the command, it would be executed after that line already, resulting in an error message: ""docker run" requires at least 1 argument(s)."